### PR TITLE
Fix unstackable items not working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<!-- Build properties -->
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<buildNumber>5</buildNumber>
+		<buildNumber>6</buildNumber>
 		<ciSystem>unknown</ciSystem>
 		<commit>unknown</commit>
 		<mainClass>org.getspout.spout.Spout</mainClass>

--- a/src/main/java/org/getspout/spout/listeners/InventoryListener.java
+++ b/src/main/java/org/getspout/spout/listeners/InventoryListener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.ItemStack;
@@ -59,16 +60,13 @@ public class InventoryListener implements Listener{
 		}
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST)
-	public void onItemCraft(CraftItemEvent e) {
-		ItemStack res = e.getCurrentItem();
-		res.removeEnchantment(SpoutEnchantment.UNSTACKABLE);
-		Material m = MaterialData.getMaterial(res.getTypeId(), res.getDurability());
-		if (m instanceof CustomItem) {
-			if (!((CustomItem) m).isStackable() && e.isShiftClick()) {
-				e.setCancelled(true); // Shift clicking causes... issues with unstackable Spout items.
-			}
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onItemCraft(CraftItemEvent event) {
+		SpoutItemStack result = new SpoutItemStack(event.getCurrentItem());
+		Material material = result.getMaterial();
+		if (result.isCustomItem() && !((CustomItem) material).isStackable() && event.isShiftClick()) {
+			event.setCancelled(true); // Shift clicking causes... issues with unstackable Spout items.
 		}
-		e.setCurrentItem(new SpoutItemStack(res)); // Handle enchantments and stuff.
+		event.setCurrentItem(result); // Handle enchantments and stuff.
 	}
 }

--- a/src/main/java/org/getspout/spout/listeners/InventoryListener.java
+++ b/src/main/java/org/getspout/spout/listeners/InventoryListener.java
@@ -25,17 +25,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
-import org.bukkit.inventory.ItemStack;
 import org.getspout.spout.Spout;
 
-import org.getspout.spoutapi.inventory.SpoutEnchantment;
 import org.getspout.spoutapi.inventory.SpoutItemStack;
 import org.getspout.spoutapi.material.CustomItem;
 import org.getspout.spoutapi.material.Material;
-import org.getspout.spoutapi.material.MaterialData;
 
 public class InventoryListener implements Listener{
 	public InventoryListener(Spout plugin) {

--- a/src/main/java/org/getspout/spout/listeners/SpoutPlayerListener.java
+++ b/src/main/java/org/getspout/spout/listeners/SpoutPlayerListener.java
@@ -44,6 +44,7 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import org.getspout.spout.PlayerChunkMap;
@@ -214,7 +215,7 @@ public class SpoutPlayerListener implements Listener {
 								// Yay, take the item from inventory
 								if (player.getGameMode() == GameMode.SURVIVAL) {
 									if (item.getAmount() == 1) {
-									// Remove this for Stuff	
+									// Remove this for Stuff
 									event.getPlayer().setItemInHand(null);
 									} else {
 										item.setAmount(item.getAmount() - 1);
@@ -338,28 +339,17 @@ public class SpoutPlayerListener implements Listener {
 		}
 	}
 
+	// These next two events are to make sure the UNSTACKABLE enchant (or any tool related ones) are applied when the item
+	// it picked up or thrown in case of plugin code changes or bugs
+
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPlayerDrop(PlayerDropItemEvent e) {
-		SpoutItemStack sis = new SpoutItemStack(e.getItemDrop().getItemStack());
-		if (!sis.containsEnchantment(SpoutEnchantment.UNSTACKABLE) && sis.isCustomItem()) {
-			CustomItem ci = (CustomItem)sis.getMaterial();
-			if (!ci.isStackable()) {
-				sis.addEnchantment(SpoutEnchantment.UNSTACKABLE, 1000);
-			}
-		}
-		e.getItemDrop().setItemStack(sis);
+	public void onPlayerDrop(PlayerDropItemEvent event) {
+		event.getItemDrop().setItemStack(new SpoutItemStack(event.getItemDrop().getItemStack()));
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPlayerPickupItem(PlayerPickupItemEvent e) {
-		SpoutItemStack sis = new SpoutItemStack(e.getItem().getItemStack());
-		if (!sis.containsEnchantment(SpoutEnchantment.UNSTACKABLE) && sis.isCustomItem()) {
-			CustomItem ci = (CustomItem)sis.getMaterial();
-			if (!ci.isStackable()) {
-				sis.addEnchantment(SpoutEnchantment.UNSTACKABLE, 1000);
-			}
-		}
-		e.getItem().setItemStack(sis);
+	public void onPlayerPickupItem(PlayerPickupItemEvent event) {
+		event.getItem().setItemStack(new SpoutItemStack(event.getItem().getItemStack()));
 	}
 }
 

--- a/src/main/java/org/getspout/spout/listeners/SpoutPlayerListener.java
+++ b/src/main/java/org/getspout/spout/listeners/SpoutPlayerListener.java
@@ -44,7 +44,6 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import org.getspout.spout.PlayerChunkMap;
@@ -55,10 +54,8 @@ import org.getspout.spout.player.SimplePlayerChunkMap;
 import org.getspout.spout.player.SpoutCraftPlayer;
 import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.block.SpoutBlock;
-import org.getspout.spoutapi.inventory.SpoutEnchantment;
 import org.getspout.spoutapi.inventory.SpoutItemStack;
 import org.getspout.spoutapi.material.CustomBlock;
-import org.getspout.spoutapi.material.CustomItem;
 import org.getspout.spoutapi.material.MaterialData;
 import org.getspout.spoutapi.packet.PacketAllowVisualCheats;
 import org.getspout.spoutapi.player.SpoutPlayer;

--- a/src/main/java/org/getspout/spoutapi/inventory/SpoutItemStack.java
+++ b/src/main/java/org/getspout/spoutapi/inventory/SpoutItemStack.java
@@ -32,17 +32,26 @@ import org.getspout.spoutapi.material.Tool;
 public class SpoutItemStack extends ItemStack {
 	public SpoutItemStack(int typeId, int amount, short data, ItemMeta meta) {
 		super(typeId, amount, data);
-		Material m = getMaterial();
-		if (m instanceof GenericCustomTool) {
+
+		if (meta != null) {
+			super.setItemMeta(meta);
+		}
+
+		Material material = getMaterial();
+
+		// Used to only run if it did not have the UNSTACKABLE enchant already. Runs every time now to keep the enchant
+		// level fresh to reduce possible exploiting to make it stackable as counter resets on server restart
+		if (material instanceof CustomItem && !((CustomItem) material).isStackable()) {
+			addUnsafeEnchantment(SpoutEnchantment.UNSTACKABLE, ((CustomItem) material).getCounter());
+		}
+
+		if (material instanceof GenericCustomTool) {
 			if (!getEnchantments().containsKey(SpoutEnchantment.MAX_DURABILITY)) {
-				addUnsafeEnchantment(SpoutEnchantment.MAX_DURABILITY, ((Tool) m).getMaxDurability());
+				addUnsafeEnchantment(SpoutEnchantment.MAX_DURABILITY, ((Tool) material).getMaxDurability());
 			}
 			if (!getEnchantments().containsKey(SpoutEnchantment.DURABILITY)) {
 				addUnsafeEnchantment(SpoutEnchantment.DURABILITY, 0);
 			}
-		}
-		if (meta != null) {
-			super.setItemMeta(meta);
 		}
 	}
 

--- a/src/main/java/org/getspout/spoutapi/material/CustomItem.java
+++ b/src/main/java/org/getspout/spoutapi/material/CustomItem.java
@@ -62,7 +62,8 @@ public interface CustomItem extends Item {
 	public boolean isStackable();
 
 	/**
-	 * Gets the next short. Starts at Short.MIN_VALUE and loopss back at Short.MAX_VALUE. This is used internally.
+	 * Gets the next short. Starts at Short.MIN_VALUE and loops back at Short.MAX_VALUE. This is used internally.
+	 * Used to give a "unique" level of the UNSTACKABLE enchant. Resets on server restart
 	 */
 	public short getCounter();
 


### PR DESCRIPTION
Wow, this was a journey of a first plugin update!

This fixes setting a Spout item to `unstackable`. It would just not do anything and remain stackable.
It seems this was broken very soon after it was added but was never fixed. From there it continued to get more and more broken making it more confusing to fix. But it should work fine now without breaking any existing functionality. 

On top of fixing unstackable items it should fix some custom tool durability thing, did not test but it seemed to be sort of related. But this was not the goal of the fix.

The feature was originally added in these two commits
https://github.com/ReSpouted/ReSpouted-LegacyServer/commit/fbe46af4fede00406ae3cea2d9694a3d1a970ec0#diff-0063950dc6dfd6e4ceab9b541378407336e1d5f3416bd00aee64b69600d2c597R35
https://github.com/ReSpouted/ReSpouted-LegacyServer/commit/a8498b1ec95db89c84ef291e7f0191eb163d4204#diff-a378cb2505c163416941e4db8884d72924ba5df17750566d9696cda8508f1ff5R34
I think it would have worked back then but it was soon broken while fixing who knows what
https://github.com/ReSpouted/ReSpouted-LegacyServer/commit/d83117585fa7276cffe8b336c22c7aacea0c5720#diff-a378cb2505c163416941e4db8884d72924ba5df17750566d9696cda8508f1ff5L35

A month later some related code was added to try and fix? improve? the unstackable code but it was already broken and this only made fixing it so much more confusing. I believe the he did not realise the code was already broken and did his best with what he had to improve it
https://github.com/ReSpouted/ReSpouted-LegacyServer/commit/bd54ddcca1aa5767afcc4c9ef7f3f98c85a3f032#diff-3bbab945b1c00a62db1f132f8ceb59da3fae11dc7f81bbb330fa72a002207371R259
The UNSTACKABLE enchantment was always set to 1000. I assume this is because the code that was removed in the last related commit had the only documentation of how to use it properly. It was meant to add the enchant level with the unsafe method, and setting the value to a counter that increases every time it is accessed, so it was not limited but he did it using the safe method which results in it always being level 1000, which still allowed them all to be stackable even if set to unstackable.

The last issue I had when I had figured that out was it did not get applied to existing items already. It worked fine for new SpoutItemStack's being created in code from plugins but not when they were thrown and picked up again. This is because when the item has existing meta it would apply the UNSTACKABLE enchant but then override it right after that.
https://github.com/ReSpouted/ReSpouted-LegacyServer/commit/8c48ef3fd113fbcdffca997217f6292a0c62cfd2#diff-a378cb2505c163416941e4db8884d72924ba5df17750566d9696cda8508f1ff5

There were a few other small steps but that covers most of my 6-7 hour journey fixing this...

There is one issue I have seen that still exists with this. When taking an unstackable item from the creative menu for Spout it does not get the enchant applied. Other than that it should work fine